### PR TITLE
Update pySigma-backend-uberAgent to support uberAgent 7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 docs/_build
 uberAgent-ESA-am-sigma-*.conf
 build/*
+.venv

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Further, it contains the following processing pipelines in `sigma.pipelines.uber
 * uberagent-7.0.0: Compatible with uberAgent 7.0.0 events and properties.
 * uberagent-7.1.0: Compatible with uberAgent 7.1.0 events and properties.
 * uberagent-7.2.0: Compatible with uberAgent 7.2.0 events and properties.
+* uberagent-7.3.0: Compatible with uberAgent 7.3.0 events and properties.
 * uberagent-develop: Compatible with the upcoming uberAgent version.
 
 It supports the following output formats:
 
 * default: Generates plain uAQL queries.
-* conf: Generates `[ActivityMonitoringRule]` configuration blocks.
+* conf: Generates `[ThreatDetectionRule]` configuration blocks.
 
 This backend is currently maintained by:
 
@@ -49,6 +50,7 @@ sigma list pipelines
 | uberagent-7.0.0   | 20       | uberAgent 7.0.0     | uberagent |
 | uberagent-7.1.0   | 20       | uberAgent 7.1.0     | uberagent |
 | uberagent-7.2.0   | 20       | uberAgent 7.2.0     | uberagent |
+| uberagent-7.3.0   | 20       | uberAgent 7.3.0     | uberagent |
 | uberagent-develop | 20       | uberAgent develop   | uberagent |
 +-------------------+----------+---------------------+-----------+
 ```

--- a/convert-rules.sh
+++ b/convert-rules.sh
@@ -95,7 +95,9 @@ for dir in ${BASE_DIR}/*; do
         # echo "Conversion completed, output saved to $OUTPUT_FILE"
 
         # Count the occurrences of [ActivityMonitoringRule] in the output file
-        RULE_COUNT=$(grep -o 'ActivityMonitoringRule' "$OUTPUT_FILE" | wc -l)
+        RULE_COUNT_AMR=$(grep -o 'ActivityMonitoringRule' "$OUTPUT_FILE" | wc -l)
+        RULE_COUNT_TDR=$(grep -o 'ThreatDetectionRule' "$OUTPUT_FILE" | wc -l)
+        RULE_COUNT=$(($RULE_COUNT_AMR + $RULE_COUNT_TDR))
 
         # Check if the file contains 0 rules
         if [ $RULE_COUNT -eq 0 ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma-backend-uberAgent"
-version = "0.3.66"
+version = "0.3.67"
 description = "pySigma uAQL backend"
 authors = ["vast limits GmbH <info@vastlimits.com>"]
 license = "MIT"

--- a/sigma/backends/uberagent/rule.py
+++ b/sigma/backends/uberagent/rule.py
@@ -127,17 +127,22 @@ class Rule:
             return self.tag
 
         return "{}-{}".format(prefixes[self.event_type], self.tag)
+    
+    def _stanza_name(self):
+        if self.version.is_version_7_2_or_newer():
+            return "ThreatDetectionRule"
+        return "ActivityMonitoringRule"
 
     def __str__(self):
         """Builds and returns the [ActivityMonitoringRule] configuration block."""
 
         # The default is available since uberagent 6.
-        result = "[ActivityMonitoringRule]\n"
+        result = "[{}]\n".format(self._stanza_name())
 
         # Starting with uberagent 7.1 and newer we slightly change the configuration stanza.
         # Example. [ActivityMonitoringRule platform=Windows] or [ActivityMonitoringRule platform=MacOS]
         if self.version.is_version_7_1_or_newer():
-            result = "[ActivityMonitoringRule"
+            result = "[{}".format(self._stanza_name())
             if self.platform in ["windows", "macos"]:
                 result += " platform="
                 if self.platform == "windows":

--- a/sigma/pipelines/uberagent/__init__.py
+++ b/sigma/pipelines/uberagent/__init__.py
@@ -1,4 +1,4 @@
-from .uberagent import uberagent, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent_develop, uberagent_test
+from .uberagent import uberagent, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent_develop
 
 pipelines = {
     "uberagent": uberagent,

--- a/sigma/pipelines/uberagent/__init__.py
+++ b/sigma/pipelines/uberagent/__init__.py
@@ -1,4 +1,4 @@
-from .uberagent import uberagent, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent_develop, uberagent_test
+from .uberagent import uberagent, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent_develop, uberagent_test
 
 pipelines = {
     "uberagent": uberagent,
@@ -8,5 +8,6 @@ pipelines = {
     "uberagent-7.0.0": uberagent700,
     "uberagent-7.1.0": uberagent710,
     "uberagent-7.2.0": uberagent720,
+    "uberagent-7.3.0": uberagent730,
     "uberagent-develop": uberagent_develop
 }

--- a/sigma/pipelines/uberagent/uberagent.py
+++ b/sigma/pipelines/uberagent/uberagent.py
@@ -16,7 +16,7 @@ from sigma.pipelines.uberagent.logsource import Logsource
 from sigma.pipelines.uberagent.transformation import ChangeLogsourceCategoryTransformation, ChangeLogsourceCategoryTransformationWindows, FieldMappingTransformationLowercase, \
     FieldDetectionItemFailureTransformation, ReferencedFieldTransformation
 from sigma.pipelines.uberagent.version import UA_VERSION_6_0, UA_VERSION_6_1, UA_VERSION_6_2, UA_VERSION_7_0, \
-    UA_VERSION_7_1, UA_VERSION_7_2, UA_VERSION_DEVELOP, UA_VERSION_CURRENT_RELEASE, Version
+    UA_VERSION_7_1, UA_VERSION_7_2, UA_VERSION_7_3, UA_VERSION_DEVELOP, UA_VERSION_CURRENT_RELEASE, Version
 
 # Maps all known Sigma fields to uberAgent Process Event Properties
 # Note: The process properties are re-usable for all event types as all events are linked to a process.
@@ -604,6 +604,16 @@ def uberagent720() -> ProcessingPipeline:
     - ProcessingPipeline: The assembled processing pipeline for version 7.2.
     """
     return make_pipeline(Version(UA_VERSION_7_2))
+
+
+def uberagent730() -> ProcessingPipeline:
+    """
+    Create a processing pipeline for version 7.3 of uberAgent.
+
+    Returns:
+    - ProcessingPipeline: The assembled processing pipeline for version 7.3.
+    """
+    return make_pipeline(Version(UA_VERSION_7_3))
 
 
 def uberagent_develop() -> ProcessingPipeline:

--- a/sigma/pipelines/uberagent/uberagent.py
+++ b/sigma/pipelines/uberagent/uberagent.py
@@ -624,13 +624,3 @@ def uberagent_develop() -> ProcessingPipeline:
     - ProcessingPipeline: The assembled processing pipeline for the development version.
     """
     return make_pipeline(Version(UA_VERSION_DEVELOP))
-
-
-def uberagent_test(version: str = UA_VERSION_DEVELOP) -> ProcessingPipeline:
-    """
-    Create a processing pipeline for the given version of uberAgent.
-
-    Returns:
-    - ProcessingPipeline: The assembled processing pipeline for the development version.
-    """
-    return make_pipeline(Version(version))

--- a/sigma/pipelines/uberagent/version.py
+++ b/sigma/pipelines/uberagent/version.py
@@ -10,10 +10,11 @@ UA_VERSION_6_2 = "6.2.0"
 UA_VERSION_7_0 = "7.0.0"
 UA_VERSION_7_1 = "7.1.0"
 UA_VERSION_7_2 = "7.2.0"
+UA_VERSION_7_3 = "7.3.0"
 
 # Represents the next upcoming version (version number not yet assigned)
 UA_VERSION_DEVELOP = "develop"
-UA_VERSION_CURRENT_RELEASE = UA_VERSION_7_2
+UA_VERSION_CURRENT_RELEASE = UA_VERSION_7_3
 
 
 class Version:
@@ -63,6 +64,9 @@ class Version:
 
     def is_version_7_2_or_newer(self) -> bool:
         return self.is_version_develop() or self._version() >= self._version_tuple(UA_VERSION_7_2)
+    
+    def is_version_7_3_or_newer(self) -> bool:
+        return self.is_version_develop() or self._version() >= self._version_tuple(UA_VERSION_7_3)
 
     def is_version_develop(self) -> bool:
         return self._outputVersion == UA_VERSION_DEVELOP
@@ -136,6 +140,9 @@ class Version:
 
         if self.is_version_7_2_or_newer() and field.version == UA_VERSION_7_2:
             return True
+        
+        if self.is_version_7_3_or_newer() and field.version == UA_VERSION_7_3:
+            return True
 
         if self.is_version_develop() and field.version == UA_VERSION_DEVELOP:
             return True
@@ -170,6 +177,9 @@ class Version:
             return True
 
         if self.is_version_7_2_or_newer() and logsource.version == UA_VERSION_7_2:
+            return True
+        
+        if self.is_version_7_3_or_newer() and logsource.version == UA_VERSION_7_3:
             return True
 
         if self.is_version_develop() and logsource.version == UA_VERSION_DEVELOP:

--- a/tests/test_pipelines_uberAgent.py
+++ b/tests/test_pipelines_uberAgent.py
@@ -4,7 +4,7 @@ from sigma.exceptions import SigmaLevelError, SigmaTransformationError, SigmaTit
 
 from sigma.backends.uberagent import uberagent
 from sigma.backends.uberagent.exceptions import MissingPropertyException, MissingFunctionException
-from sigma.pipelines.uberagent import uberagent as uberagent_pipeline, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent_develop, uberagent_test
+from sigma.pipelines.uberagent import uberagent as uberagent_pipeline, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent_develop
 
 
 def test_ua_windows():
@@ -277,7 +277,7 @@ def test_rule_unknown_risk_score():
 
 def test_rule_not_supported():
     with pytest.raises(Exception):
-        assert uberagent(processing_pipeline=uberagent_test("6.0.0")).convert(
+        assert uberagent(processing_pipeline=uberagent600()).convert(
             SigmaCollection.from_yaml("""
                 title: Test
                 id: 01234567-1234-5678-1234-567890123456

--- a/tests/test_pipelines_uberAgent.py
+++ b/tests/test_pipelines_uberAgent.py
@@ -4,7 +4,7 @@ from sigma.exceptions import SigmaLevelError, SigmaTransformationError, SigmaTit
 
 from sigma.backends.uberagent import uberagent
 from sigma.backends.uberagent.exceptions import MissingPropertyException, MissingFunctionException
-from sigma.pipelines.uberagent import uberagent as uberagent_pipeline, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent_develop, uberagent_test
+from sigma.pipelines.uberagent import uberagent as uberagent_pipeline, uberagent600, uberagent610, uberagent620, uberagent700, uberagent710, uberagent720, uberagent730, uberagent_develop, uberagent_test
 
 
 def test_ua_windows():
@@ -173,7 +173,7 @@ def test_rule_annotation_with_author():
         'Annotation = {"mitre_attack": ["T0001", "T0002"], "author": "Unit Test"}\n' \
         'Query = Process.Path == "test" and Process.CommandLine == "test"\n'
 
-    assert uberagent(processing_pipeline=uberagent_develop()).convert(
+    assert uberagent(processing_pipeline=uberagent720()).convert(
         SigmaCollection.from_yaml("""
             id: 01234567-1234-5678-1234-567890123456
             title: Test
@@ -207,7 +207,7 @@ def test_rule_annotation_with_author_without_mitre_tags():
         'Annotation = {"author": "Unit Test"}\n' \
         'Query = Process.Path == "test" and Process.CommandLine == "test"\n'
 
-    assert uberagent(processing_pipeline=uberagent_develop()).convert(
+    assert uberagent(processing_pipeline=uberagent720()).convert(
         SigmaCollection.from_yaml("""
             id: 01234567-1234-5678-1234-567890123456
             title: Test
@@ -397,6 +397,23 @@ def test_uberagent720():
     ) == ['Process.Path == "test" and Process.CommandLine == "test"']
 
 
+def test_uberagent730():
+    assert uberagent(processing_pipeline=uberagent730()).convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                product: windows
+                category: process_creation
+            detection:
+                sel:
+                    Image: test
+                    CommandLine: test
+                condition: sel
+        """)
+    ) == ['Process.Path == "test" and Process.CommandLine == "test"']
+
+
 def test_uberagent_develop():
     assert uberagent(processing_pipeline=uberagent_develop()).convert(
         SigmaCollection.from_yaml("""
@@ -431,7 +448,7 @@ def test_uberagent_620_isnull():
 
 
 def test_uberagent_registry_createkey():
-    assert uberagent(processing_pipeline=uberagent_develop()).convert(
+    assert uberagent(processing_pipeline=uberagent720()).convert(
         SigmaCollection.from_yaml("""
             title: Test
             status: test
@@ -446,7 +463,7 @@ def test_uberagent_registry_createkey():
 
 
 def test_uberagent_registry_deletekey():
-    assert uberagent(processing_pipeline=uberagent_develop()).convert(
+    assert uberagent(processing_pipeline=uberagent720()).convert(
         SigmaCollection.from_yaml("""
             title: Test
             status: test
@@ -461,7 +478,7 @@ def test_uberagent_registry_deletekey():
 
 
 def test_uberagent_registry_renamekey():
-    assert uberagent(processing_pipeline=uberagent_develop()).convert(
+    assert uberagent(processing_pipeline=uberagent720()).convert(
         SigmaCollection.from_yaml("""
             title: Test
             status: test
@@ -476,7 +493,7 @@ def test_uberagent_registry_renamekey():
 
 
 def test_uberagent_registry_deletevalue():
-    assert uberagent(processing_pipeline=uberagent_develop()).convert(
+    assert uberagent(processing_pipeline=uberagent720()).convert(
         SigmaCollection.from_yaml("""
             title: Test
             status: test
@@ -491,7 +508,7 @@ def test_uberagent_registry_deletevalue():
 
 
 def test_uberagent_registry_setvalue():
-    assert uberagent(processing_pipeline=uberagent_develop()).convert(
+    assert uberagent(processing_pipeline=uberagent720()).convert(
         SigmaCollection.from_yaml("""
             title: Test
             status: test
@@ -507,7 +524,7 @@ def test_uberagent_registry_setvalue():
 
 def test_uberagent_registry_unsupported_createvalue():
     with pytest.raises(SigmaTransformationError):
-        uberagent(processing_pipeline=uberagent_develop()).convert(
+        uberagent(processing_pipeline=uberagent720()).convert(
             SigmaCollection.from_yaml("""
                 title: Test
                 status: test
@@ -523,7 +540,7 @@ def test_uberagent_registry_unsupported_createvalue():
 
 def test_uberagent_registry_unsupported_renamevalue():
     with pytest.raises(SigmaTransformationError):
-        uberagent(processing_pipeline=uberagent_develop()).convert(
+        uberagent(processing_pipeline=uberagent720()).convert(
             SigmaCollection.from_yaml("""
                 title: Test
                 status: test

--- a/tests/test_pipelines_uberAgent.py
+++ b/tests/test_pipelines_uberAgent.py
@@ -42,7 +42,7 @@ def test_ua_macos():
 
 def test_rule_process_creation():
     expected = \
-        '[ActivityMonitoringRule platform=Windows]\n' \
+        '[ThreatDetectionRule platform=Windows]\n' \
         'RuleId = 01234567-1234-5678-1234-567890123456\n' \
         'RuleName = Test\n' \
         'EventType = Process.Start\n' \
@@ -104,7 +104,7 @@ def test_rule_requires_title():
 
 def test_rule_description():
     expected = \
-        '[ActivityMonitoringRule platform=Windows]\n' \
+        '[ThreatDetectionRule platform=Windows]\n' \
         '# This is a test rule.\n' \
         'RuleId = 01234567-1234-5678-1234-567890123456\n' \
         'RuleName = Test\n' \
@@ -131,7 +131,7 @@ def test_rule_description():
 
 def test_rule_annotation():
     expected = \
-        '[ActivityMonitoringRule platform=Windows]\n' \
+        '[ThreatDetectionRule platform=Windows]\n' \
         '# This is a test rule.\n' \
         'RuleId = 01234567-1234-5678-1234-567890123456\n' \
         'RuleName = Test\n' \
@@ -163,7 +163,7 @@ def test_rule_annotation():
 
 def test_rule_annotation_with_author():
     expected = \
-        '[ActivityMonitoringRule platform=Windows]\n' \
+        '[ThreatDetectionRule platform=Windows]\n' \
         '# This is a test rule.\n' \
         '# Author: Unit Test\n' \
         'RuleId = 01234567-1234-5678-1234-567890123456\n' \
@@ -197,7 +197,7 @@ def test_rule_annotation_with_author():
 
 def test_rule_annotation_with_author_without_mitre_tags():
     expected = \
-        '[ActivityMonitoringRule platform=Windows]\n' \
+        '[ThreatDetectionRule platform=Windows]\n' \
         '# This is a test rule.\n' \
         '# Author: Unit Test\n' \
         'RuleId = 01234567-1234-5678-1234-567890123456\n' \
@@ -228,7 +228,7 @@ def test_rule_annotation_with_author_without_mitre_tags():
 # Test "common" rule without specific product.
 def test_rule_network_any_common():
     expected = \
-        '[ActivityMonitoringRule]\n' \
+        '[ThreatDetectionRule]\n' \
         'RuleId = 01234567-1234-5678-1234-567890123456\n' \
         'RuleName = Test\n' \
         'EventType = Net.Any\n' \

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sigma.backends.uberagent.rule import MalformedRuleException, Rule
-from sigma.pipelines.uberagent.version import Version
+from sigma.pipelines.uberagent.version import UA_VERSION_DEVELOP, Version
 
 WITH_FIELD_RULE_ID = True
 WITH_FIELD_ANNOTATION = True
@@ -10,16 +10,19 @@ WITHOUT_FIELD_ANNOTATION = False
 WITH_HIVE = True
 WITHOUT_HIVE = False
 
+STANZA_AMR = "ActivityMonitoringRule"
+STANZA_TDR = "ThreatDetectionRule"
+
 def test_rule_minimum_fields():
     expected = \
-        '[ActivityMonitoringRule]\n' \
+        '[ThreatDetectionRule]\n' \
         'RuleId = Test\n' \
         'RuleName = Test\n' \
         'EventType = Test\n' \
         'Tag = Test\n' \
         'Query = true\n'
 
-    rule = Rule(Version("develop"))
+    rule = Rule(Version(UA_VERSION_DEVELOP))
     rule.set_id("Test")
     rule.set_event_type("Test")
     rule.set_tag("Test")
@@ -53,27 +56,27 @@ def test_rule_creation(version, method_values, expected_exception):
         str(rule)  # Should not raise any exception
 
 
-@pytest.mark.parametrize("version,with_id", [
-    ("6.0.0", WITHOUT_FIELD_RULE_ID),
-    ("6.1.0", WITHOUT_FIELD_RULE_ID),
-    ("6.2.0", WITHOUT_FIELD_RULE_ID),
-    ("7.0.0", WITH_FIELD_RULE_ID),
-    ("7.1.0", WITH_FIELD_RULE_ID),
-    ("develop", WITH_FIELD_RULE_ID),
-    ("main", WITH_FIELD_RULE_ID)
+@pytest.mark.parametrize("version,with_id,stanza", [
+    ("6.0.0", WITHOUT_FIELD_RULE_ID, STANZA_AMR),
+    ("6.1.0", WITHOUT_FIELD_RULE_ID, STANZA_AMR),
+    ("6.2.0", WITHOUT_FIELD_RULE_ID, STANZA_AMR),
+    ("7.0.0", WITH_FIELD_RULE_ID, STANZA_AMR),
+    ("7.1.0", WITH_FIELD_RULE_ID, STANZA_AMR),
+    ("7.2.0", WITH_FIELD_RULE_ID, STANZA_TDR),
+    ("7.3.0", WITH_FIELD_RULE_ID, STANZA_TDR),
+    ("develop", WITH_FIELD_RULE_ID, STANZA_TDR),
+    ("main", WITH_FIELD_RULE_ID, STANZA_TDR)
 ])
-def test_rule_id(version, with_id):
-    expected_with_id = \
-        '[ActivityMonitoringRule]\n' \
-        'RuleId = Test\n' \
+def test_rule_id(version, with_id, stanza):
+    expected_with_id = '[{}]\n'.format(stanza)
+    expected_with_id += 'RuleId = Test\n' \
         'RuleName = Test\n' \
         'EventType = Test\n' \
         'Tag = Test\n' \
         'Query = true\n'
 
-    expected_without_id = \
-        '[ActivityMonitoringRule]\n' \
-        'RuleName = Test\n' \
+    expected_without_id = '[{}]\n'.format(stanza)
+    expected_without_id += 'RuleName = Test\n' \
         'EventType = Test\n' \
         'Tag = Test\n' \
         'Query = true\n'
@@ -90,28 +93,28 @@ def test_rule_id(version, with_id):
         assert str(rule) == expected_without_id
 
 
-@pytest.mark.parametrize("version,with_id,with_annotation", [
-    ("6.0.0", WITHOUT_FIELD_RULE_ID, WITHOUT_FIELD_ANNOTATION),
-    ("6.1.0", WITHOUT_FIELD_RULE_ID, WITHOUT_FIELD_ANNOTATION),
-    ("6.2.0", WITHOUT_FIELD_RULE_ID, WITHOUT_FIELD_ANNOTATION),
-    ("7.0.0", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION),
-    ("7.1.0", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION),
-    ("develop", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION),
-    ("main", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION)
+@pytest.mark.parametrize("version,with_id,with_annotation,stanza", [
+    ("6.0.0", WITHOUT_FIELD_RULE_ID, WITHOUT_FIELD_ANNOTATION, STANZA_AMR),
+    ("6.1.0", WITHOUT_FIELD_RULE_ID, WITHOUT_FIELD_ANNOTATION, STANZA_AMR),
+    ("6.2.0", WITHOUT_FIELD_RULE_ID, WITHOUT_FIELD_ANNOTATION, STANZA_AMR),
+    ("7.0.0", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION, STANZA_AMR),
+    ("7.1.0", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION, STANZA_AMR),
+    ("7.2.0", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION, STANZA_TDR),
+    ("7.3.0", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION, STANZA_TDR),
+    ("develop", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION, STANZA_TDR),
+    ("main", WITH_FIELD_RULE_ID, WITH_FIELD_ANNOTATION, STANZA_TDR)
 ])
-def test_rule_annotation(version, with_id, with_annotation):
-    expected_with = \
-        '[ActivityMonitoringRule]\n' \
-        'RuleId = Test\n' \
+def test_rule_annotation(version, with_id, with_annotation, stanza):
+    expected_with = '[{}]\n'.format(stanza)
+    expected_with += 'RuleId = Test\n' \
         'RuleName = Test\n' \
         'EventType = Test\n' \
         'Tag = Test\n' \
         'Annotation = Test\n' \
         'Query = true\n'
 
-    expected_without = \
-        '[ActivityMonitoringRule]\n' \
-        'RuleName = Test\n' \
+    expected_without = '[{}]\n'.format(stanza)
+    expected_without += 'RuleName = Test\n' \
         'EventType = Test\n' \
         'Tag = Test\n' \
         'Query = true\n'
@@ -141,6 +144,8 @@ def test_rule_annotation(version, with_id, with_annotation):
     ("6.2.0", "Process.Start", WITHOUT_HIVE),
     ("7.0.0", "Process.Start", WITHOUT_HIVE),
     ("7.1.0", "Process.Start", WITHOUT_HIVE),
+    ("7.2.0", "Process.Start", WITHOUT_HIVE),
+    ("7.3.0", "Process.Start", WITHOUT_HIVE),
     ("develop", "Process.Start", WITHOUT_HIVE),
     ("main", "Process.Start", WITHOUT_HIVE)
 ])
@@ -158,14 +163,14 @@ def test_rule_reg_hive(version, event_type, with_hive):
 
 def test_rule_platform_windows():
     expected = \
-        '[ActivityMonitoringRule platform=Windows]\n' \
+        '[ThreatDetectionRule platform=Windows]\n' \
         'RuleId = Test\n' \
         'RuleName = Test\n' \
         'EventType = Test\n' \
         'Tag = Test\n' \
         'Query = true\n'
 
-    rule = Rule(Version("develop"))
+    rule = Rule(Version(UA_VERSION_DEVELOP))
     rule.set_platform("windows")
     rule.set_id("Test")
     rule.set_event_type("Test")
@@ -177,14 +182,14 @@ def test_rule_platform_windows():
 
 def test_rule_platform_macos():
     expected = \
-        '[ActivityMonitoringRule platform=MacOS]\n' \
+        '[ThreatDetectionRule platform=MacOS]\n' \
         'RuleId = Test\n' \
         'RuleName = Test\n' \
         'EventType = Test\n' \
         'Tag = Test\n' \
         'Query = true\n'
 
-    rule = Rule(Version("develop"))
+    rule = Rule(Version(UA_VERSION_DEVELOP))
     rule.set_platform("macos")
     rule.set_id("Test")
     rule.set_event_type("Test")
@@ -196,7 +201,7 @@ def test_rule_platform_macos():
 
 def test_rule_author_description():
     expected = \
-        '[ActivityMonitoringRule platform=MacOS]\n' \
+        '[ThreatDetectionRule platform=MacOS]\n' \
         '# Test Description\n' \
         '# Author: Test\n' \
         'RuleId = Test\n' \
@@ -205,7 +210,7 @@ def test_rule_author_description():
         'Tag = Test\n' \
         'Query = true\n'
 
-    rule = Rule(Version("develop"))
+    rule = Rule(Version(UA_VERSION_DEVELOP))
     rule.set_platform("macos")
     rule.set_id("Test")
     rule.set_event_type("Test")
@@ -218,7 +223,7 @@ def test_rule_author_description():
 
 def test_rule_generic_properties():
     expected = \
-        '[ActivityMonitoringRule]\n' \
+        '[ThreatDetectionRule]\n' \
         'RuleId = Test\n' \
         'RuleName = Test\n' \
         'EventType = Test\n' \
@@ -235,7 +240,7 @@ def test_rule_generic_properties():
         'GenericProperty9 = Field9\n' \
         'GenericProperty10 = Field10\n'
 
-    rule = Rule(Version("develop"))
+    rule = Rule(Version(UA_VERSION_DEVELOP))
     rule.set_id("Test")
     rule.set_event_type("Test")
     rule.set_tag("Test")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -12,6 +12,7 @@ from sigma.pipelines.uberagent.field import Field
    (UA_VERSION_7_0, True),
    (UA_VERSION_7_1, True),
    (UA_VERSION_7_2, True),
+   (UA_VERSION_7_3, True),
    (UA_VERSION_DEVELOP, True),
 ])
 def test_version_6_1(version, expected):
@@ -25,6 +26,7 @@ def test_version_6_1(version, expected):
    (UA_VERSION_7_0, True),
    (UA_VERSION_7_1, True),
    (UA_VERSION_7_2, True),
+   (UA_VERSION_7_3, True),
    (UA_VERSION_DEVELOP, True),
 ])
 def test_version_6_2(version, expected):
@@ -38,6 +40,7 @@ def test_version_6_2(version, expected):
    (UA_VERSION_7_0, True),
    (UA_VERSION_7_1, True),
    (UA_VERSION_7_2, True),
+   (UA_VERSION_7_3, True),
    (UA_VERSION_DEVELOP, True),
 ])
 def test_version_7_0(version, expected):
@@ -176,6 +179,10 @@ def test_logsource_supported(logsource_version, version, expected):
    field: Field = Field(logsource_version, "TestField")
    version_object: Version = Version(version)
    assert version_object.is_logsource_supported(Logsource(logsource_version, "Test")) == expected and version_object.is_field_supported(field) == expected
+
+
+def test_current_release():
+   assert UA_VERSION_CURRENT_RELEASE == UA_VERSION_7_3
 
 
 def test_version_str():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -103,7 +103,6 @@ def test_version_develop(version, expected):
    assert Version(version).is_version_develop() == expected
 
 
-
 @pytest.mark.parametrize("platform,version,expected", [
    ("windows", UA_VERSION_6_0, True),
    ("windows", UA_VERSION_6_1, True),
@@ -166,6 +165,22 @@ def test_version_develop(platform,version, expected):
    (UA_VERSION_7_1, UA_VERSION_7_2, True),
    (UA_VERSION_7_1, UA_VERSION_7_3, True),
    (UA_VERSION_7_1, UA_VERSION_DEVELOP, True),
+
+   (UA_VERSION_7_2, UA_VERSION_6_0, False),
+   (UA_VERSION_7_2, UA_VERSION_6_1, False),
+   (UA_VERSION_7_2, UA_VERSION_7_0, False),
+   (UA_VERSION_7_2, UA_VERSION_7_1, False),
+   (UA_VERSION_7_2, UA_VERSION_7_2, True),
+   (UA_VERSION_7_2, UA_VERSION_7_3, True),
+   (UA_VERSION_7_2, UA_VERSION_DEVELOP, True),
+
+   (UA_VERSION_7_3, UA_VERSION_6_0, False),
+   (UA_VERSION_7_3, UA_VERSION_6_1, False),
+   (UA_VERSION_7_3, UA_VERSION_7_0, False),
+   (UA_VERSION_7_3, UA_VERSION_7_1, False),
+   (UA_VERSION_7_3, UA_VERSION_7_2, False),
+   (UA_VERSION_7_3, UA_VERSION_7_3, True),
+   (UA_VERSION_7_3, UA_VERSION_DEVELOP, True),
 
    (UA_VERSION_DEVELOP, UA_VERSION_6_0, False),
    (UA_VERSION_DEVELOP, UA_VERSION_6_1, False),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sigma.pipelines.uberagent.version import Version, UA_VERSION_6_0, UA_VERSION_6_1, UA_VERSION_6_2, UA_VERSION_7_0, UA_VERSION_7_1, UA_VERSION_7_2, UA_VERSION_CURRENT_RELEASE, UA_VERSION_DEVELOP
+from sigma.pipelines.uberagent.version import Version, UA_VERSION_6_0, UA_VERSION_6_1, UA_VERSION_6_2, UA_VERSION_7_0, UA_VERSION_7_1, UA_VERSION_7_2, UA_VERSION_7_3, UA_VERSION_CURRENT_RELEASE, UA_VERSION_DEVELOP
 from sigma.pipelines.uberagent.logsource import Logsource
 from sigma.pipelines.uberagent.field import Field
 
@@ -51,6 +51,7 @@ def test_version_7_0(version, expected):
    (UA_VERSION_7_0, False),
    (UA_VERSION_7_1, True),
    (UA_VERSION_7_2, True),
+   (UA_VERSION_7_3, True),
    (UA_VERSION_DEVELOP, True),
 ])
 def test_version_7_1(version, expected):
@@ -63,7 +64,36 @@ def test_version_7_1(version, expected):
    (UA_VERSION_6_2, False),
    (UA_VERSION_7_0, False),
    (UA_VERSION_7_1, False),
+   (UA_VERSION_7_2, True),
+   (UA_VERSION_7_3, True),
+   (UA_VERSION_DEVELOP, True),
+])
+def test_version_7_2(version, expected):
+   assert Version(version).is_version_7_2_or_newer() == expected
+
+
+@pytest.mark.parametrize("version,expected", [
+   (UA_VERSION_6_0, False),
+   (UA_VERSION_6_1, False),
+   (UA_VERSION_6_2, False),
+   (UA_VERSION_7_0, False),
+   (UA_VERSION_7_1, False),
    (UA_VERSION_7_2, False),
+   (UA_VERSION_7_3, True),
+   (UA_VERSION_DEVELOP, True),
+])
+def test_version_7_3(version, expected):
+   assert Version(version).is_version_7_3_or_newer() == expected
+
+
+@pytest.mark.parametrize("version,expected", [
+   (UA_VERSION_6_0, False),
+   (UA_VERSION_6_1, False),
+   (UA_VERSION_6_2, False),
+   (UA_VERSION_7_0, False),
+   (UA_VERSION_7_1, False),
+   (UA_VERSION_7_2, False),
+   (UA_VERSION_7_3, False),
    (UA_VERSION_DEVELOP, True),
 ])
 def test_version_develop(version, expected):
@@ -78,6 +108,7 @@ def test_version_develop(version, expected):
    ("windows", UA_VERSION_7_0, True),
    ("windows", UA_VERSION_7_1, True),
    ("windows", UA_VERSION_7_2, True),
+   ("windows", UA_VERSION_7_3, True),
    ("windows", UA_VERSION_DEVELOP, True),
    ("common", UA_VERSION_6_0, True),
    ("common", UA_VERSION_6_1, True),
@@ -85,6 +116,7 @@ def test_version_develop(version, expected):
    ("common", UA_VERSION_7_0, True),
    ("common", UA_VERSION_7_1, True),
    ("common", UA_VERSION_7_2, True),
+   ("common", UA_VERSION_7_3, True),
    ("common", UA_VERSION_DEVELOP, True),
    ("macos", UA_VERSION_6_0, False),
    ("macos", UA_VERSION_6_1, False),
@@ -92,6 +124,7 @@ def test_version_develop(version, expected):
    ("macos", UA_VERSION_7_0, False),
    ("macos", UA_VERSION_7_1, True),
    ("macos", UA_VERSION_7_2, True),
+   ("macos", UA_VERSION_7_3, True),
    ("macos", UA_VERSION_DEVELOP, True),
 ])
 def test_version_develop(platform,version, expected):
@@ -104,6 +137,7 @@ def test_version_develop(platform,version, expected):
    (UA_VERSION_6_0, UA_VERSION_7_0, True),
    (UA_VERSION_6_0, UA_VERSION_7_1, True),
    (UA_VERSION_6_0, UA_VERSION_7_2, True),
+   (UA_VERSION_6_0, UA_VERSION_7_3, True),
    (UA_VERSION_6_0, UA_VERSION_DEVELOP, True),
 
    (UA_VERSION_6_1, UA_VERSION_6_0, False),
@@ -111,6 +145,7 @@ def test_version_develop(platform,version, expected):
    (UA_VERSION_6_1, UA_VERSION_7_0, True),
    (UA_VERSION_6_1, UA_VERSION_7_1, True),
    (UA_VERSION_6_1, UA_VERSION_7_2, True),
+   (UA_VERSION_6_1, UA_VERSION_7_3, True),
    (UA_VERSION_6_1, UA_VERSION_DEVELOP, True),
 
    (UA_VERSION_7_0, UA_VERSION_6_0, False),
@@ -118,6 +153,7 @@ def test_version_develop(platform,version, expected):
    (UA_VERSION_7_0, UA_VERSION_7_0, True),
    (UA_VERSION_7_0, UA_VERSION_7_1, True),
    (UA_VERSION_7_0, UA_VERSION_7_2, True),
+   (UA_VERSION_7_0, UA_VERSION_7_3, True),
    (UA_VERSION_7_0, UA_VERSION_DEVELOP, True),
 
    (UA_VERSION_7_1, UA_VERSION_6_0, False),
@@ -125,6 +161,7 @@ def test_version_develop(platform,version, expected):
    (UA_VERSION_7_1, UA_VERSION_7_0, False),
    (UA_VERSION_7_1, UA_VERSION_7_1, True),
    (UA_VERSION_7_1, UA_VERSION_7_2, True),
+   (UA_VERSION_7_1, UA_VERSION_7_3, True),
    (UA_VERSION_7_1, UA_VERSION_DEVELOP, True),
 
    (UA_VERSION_DEVELOP, UA_VERSION_6_0, False),
@@ -132,6 +169,7 @@ def test_version_develop(platform,version, expected):
    (UA_VERSION_DEVELOP, UA_VERSION_7_0, False),
    (UA_VERSION_DEVELOP, UA_VERSION_7_1, False),
    (UA_VERSION_DEVELOP, UA_VERSION_7_2, False),
+   (UA_VERSION_DEVELOP, UA_VERSION_7_3, False),
    (UA_VERSION_DEVELOP, UA_VERSION_DEVELOP, True),
 ])
 def test_logsource_supported(logsource_version, version, expected):


### PR DESCRIPTION
This PR enables uberAgent 7.3 support.

Additionally, the following changes were implemented:

- Support `[ThreatDetectionRule]` stanza generation starting with uberAgent 7.2.
